### PR TITLE
Add new "GPS Off" feature

### DIFF
--- a/resources/strings/general_strings.xml
+++ b/resources/strings/general_strings.xml
@@ -3,7 +3,7 @@
 
 	<string id="BatterySaver_StorageID"   >batter_saver</string>
 	<string id="NCAAMode_StorageID"       >ncaa_mode</string>
-    <string id="GPSOff_StorageID"         >gps_off</string>
+	<string id="GPSOff_StorageID"         >gps_off</string>
 	<string id="DarkMode_StorageID"       >background_color</string>
 	<string id="ThickRing_StorageID"       >thick_ring</string>
 

--- a/resources/strings/general_strings.xml
+++ b/resources/strings/general_strings.xml
@@ -3,6 +3,7 @@
 
 	<string id="BatterySaver_StorageID"   >batter_saver</string>
 	<string id="NCAAMode_StorageID"       >ncaa_mode</string>
+    <string id="GPSOff_StorageID"         >gps_off</string>
 	<string id="DarkMode_StorageID"       >background_color</string>
 	<string id="ThickRing_StorageID"       >thick_ring</string>
 

--- a/resources/strings/main_menu_strings.xml
+++ b/resources/strings/main_menu_strings.xml
@@ -5,6 +5,7 @@
     <string id="TimingMenu_MenuLabel"     >Match Times</string>
     <string id="BatterySaver_MenuLabel"   >Battery Saver</string>
     <string id="NCAAMode_MenuLabel"       >NCAA Mode</string>
+    <string id="GPSOff_MenuLabel"         >GPS Off</string>
     <string id="DarkMode_MenuLabel"       >Dark Mode</string>
     <string id="ThickRing_MenuLabel"      >Thick Time Ring</string>
 </strings>

--- a/source/AppData.mc
+++ b/source/AppData.mc
@@ -19,6 +19,8 @@ using Toybox.Application.Storage as Store;
 using Toybox.Test;
 using Toybox.WatchUi as Ui;
 using Toybox.Graphics as Gfx;
+using Toybox.Position;
+using Toybox.Lang;
 
 using RefreshTimer as RTime;
 using ViewDrawables as draw;
@@ -256,6 +258,14 @@ class AppData {
 
     static function setGPSOff(val) {
         gpsOff = val;
+
+        var callback = new Lang.Method(RefWatchApp, :onPosition);
+        if (val) {
+            Position.enableLocationEvents(Position.LOCATION_DISABLE, callback);
+        } else {
+            Position.enableLocationEvents(Position.LOCATION_CONTINUOUS, callback);
+        }
+
         Store.setValue(Ui.loadResource(Rez.Strings.GPSOff_StorageID), val);
     }
 	

--- a/source/AppData.mc
+++ b/source/AppData.mc
@@ -28,7 +28,7 @@ using ViewDrawables as draw;
 class AppData {
 	hidden static var batterySaver;
 	hidden static var ncaaMode;
-    hidden static var gpsOff;
+	hidden static var gpsOff;
 	hidden static var darkMode;
 	hidden static var thickRing;
 	
@@ -131,9 +131,9 @@ class AppData {
     		case Ui.loadResource(Rez.Strings.NCAAMode_StorageID)   :
         		return ncaaMode;
         		break;
-            case Ui.loadResource(Rez.Strings.GPSOff_StorageID)   :
-        		return gpsOff;
-        		break;
+			case Ui.loadResource(Rez.Strings.GPSOff_StorageID)   :
+				return gpsOff;
+				break;
     		case Ui.loadResource(Rez.Strings.DarkMode_StorageID)   :
         		return darkMode;
         		break;
@@ -208,8 +208,8 @@ class AppData {
 		return ncaaMode;
 	}
 
-    static function getGPSOff() {
-        return gpsOff;
+	static function getGPSOff() {
+		return gpsOff;
     }
 	
 	static function getDarkMode() {
@@ -256,18 +256,18 @@ class AppData {
 		Store.setValue(Ui.loadResource(Rez.Strings.NCAAMode_StorageID), val);
 	}
 
-    static function setGPSOff(val) {
-        gpsOff = val;
+	static function setGPSOff(val) {
+		gpsOff = val;
 
-        var callback = new Lang.Method(RefWatchApp, :onPosition);
-        if (val) {
-            Position.enableLocationEvents(Position.LOCATION_DISABLE, callback);
-        } else {
-            Position.enableLocationEvents(Position.LOCATION_CONTINUOUS, callback);
-        }
+		var callback = new Lang.Method(RefWatchApp, :onPosition);
+		if (val) {
+			Position.enableLocationEvents(Position.LOCATION_DISABLE, callback);
+		} else {
+			Position.enableLocationEvents(Position.LOCATION_CONTINUOUS, callback);
+		}
 
-        Store.setValue(Ui.loadResource(Rez.Strings.GPSOff_StorageID), val);
-    }
+		Store.setValue(Ui.loadResource(Rez.Strings.GPSOff_StorageID), val);
+	}
 	
 	static function setDarkMode(val) {
 		darkMode = val;

--- a/source/AppData.mc
+++ b/source/AppData.mc
@@ -26,6 +26,7 @@ using ViewDrawables as draw;
 class AppData {
 	hidden static var batterySaver;
 	hidden static var ncaaMode;
+    hidden static var gpsOff;
 	hidden static var darkMode;
 	hidden static var thickRing;
 	
@@ -49,6 +50,11 @@ class AppData {
         ncaaMode        = Store.getValue(Ui.loadResource(Rez.Strings.NCAAMode_StorageID));
         if (ncaaMode == null) {
             setNCAAMode(false);
+        }
+
+        gpsOff        = Store.getValue(Ui.loadResource(Rez.Strings.GPSOff_StorageID));
+        if (gpsOff == null) {
+            setGPSOff(false);
         }
     
 		darkMode        = Store.getValue(Ui.loadResource(Rez.Strings.DarkMode_StorageID));
@@ -95,6 +101,9 @@ class AppData {
 
     static function refreshAppData() {
         ncaaMode       = Store.getValue(Ui.loadResource(Rez.Strings.NCAAMode_StorageID));
+
+        gpsOff         = Store.getValue(Ui.loadResource(Rez.Strings.GPSOff_StorageID));
+        setGPSOff(gpsOff);
     	
     	batterySaver   = Store.getValue(Ui.loadResource(Rez.Strings.BatterySaver_StorageID));
     	RTime.updateBatterSaver(batterySaver);
@@ -119,6 +128,9 @@ class AppData {
         		break;
     		case Ui.loadResource(Rez.Strings.NCAAMode_StorageID)   :
         		return ncaaMode;
+        		break;
+            case Ui.loadResource(Rez.Strings.GPSOff_StorageID)   :
+        		return gpsOff;
         		break;
     		case Ui.loadResource(Rez.Strings.DarkMode_StorageID)   :
         		return darkMode;
@@ -155,6 +167,9 @@ class AppData {
     		case Ui.loadResource(Rez.Strings.NCAAMode_StorageID)   :
         		setNCAAMode(val);
         		break;
+            case Ui.loadResource(Rez.Strings.GPSOff_StorageID)   :
+        		setGPSOff(val);
+        		break;
     		case Ui.loadResource(Rez.Strings.DarkMode_StorageID)   :
         		setDarkMode(val);
         		break;
@@ -190,6 +205,10 @@ class AppData {
 	static function getNCAAMode() {
 		return ncaaMode;
 	}
+
+    static function getGPSOff() {
+        return gpsOff;
+    }
 	
 	static function getDarkMode() {
 		return darkMode;
@@ -234,6 +253,11 @@ class AppData {
 		ncaaMode = val;
 		Store.setValue(Ui.loadResource(Rez.Strings.NCAAMode_StorageID), val);
 	}
+
+    static function setGPSOff(val) {
+        gpsOff = val;
+        Store.setValue(Ui.loadResource(Rez.Strings.GPSOff_StorageID), val);
+    }
 	
 	static function setDarkMode(val) {
 		darkMode = val;

--- a/source/UI/Menus/MainMenuInputDelegate.mc
+++ b/source/UI/Menus/MainMenuInputDelegate.mc
@@ -41,6 +41,9 @@ class MainMenuInputDelegate extends Ui.Menu2InputDelegate {
 		 	case :NCAAMode_MenuID       :
 		 		AppData.setNCAAMode(item.isEnabled());
                 break;
+            case :GPSOff_MenuID       :
+		 		AppData.setGPSOff(item.isEnabled());
+                break;
  			case :BatterySaver_MenuID   :
                 AppData.setBatterySaver(item.isEnabled());
                 break;

--- a/source/UI/Menus/MainMenuInputDelegate.mc
+++ b/source/UI/Menus/MainMenuInputDelegate.mc
@@ -41,9 +41,9 @@ class MainMenuInputDelegate extends Ui.Menu2InputDelegate {
 		 	case :NCAAMode_MenuID       :
 		 		AppData.setNCAAMode(item.isEnabled());
                 break;
-            case :GPSOff_MenuID       :
-		 		AppData.setGPSOff(item.isEnabled());
-                break;
+			case :GPSOff_MenuID       :
+				AppData.setGPSOff(item.isEnabled());
+				break;
  			case :BatterySaver_MenuID   :
                 AppData.setBatterySaver(item.isEnabled());
                 break;

--- a/source/UI/Menus/Menus.mc
+++ b/source/UI/Menus/Menus.mc
@@ -36,6 +36,10 @@ module Menus {
 		menu.addItem(
 			new Ui.ToggleMenuItem(Rez.Strings.NCAAMode_MenuLabel, null, :NCAAMode_MenuID, AppData.getNCAAMode(), null)
 		);
+
+		menu.addItem(
+			new Ui.ToggleMenuItem(Rez.Strings.GPSOff_MenuLabel, null, :GPSOff_MenuID, AppData.getGPSOff(), null)
+		);
 		
 		menu.addItem(
 			new Ui.ToggleMenuItem(Rez.Strings.BatterySaver_MenuLabel, null, :BatterySaver_MenuID, AppData.getBatterySaver(), null)


### PR DESCRIPTION
Often an app user will want to disable GPS during a match. Perhaps it is an indoor match; or they want to save battery; or they don't care about tracking distance while in the role of AR or 4th official.

This PR adds a new "GPS Off" item to the settings menu. When the toggle switch is active, GPS is disabled.

Note that this does not necessarily disable distance measurements or estimates. Individual devices may still measure or estimate distance via on-device or external sensors (i.e. stride length estimates via a watch or foot pod).

See issue #11.