### PR TITLE
Stop activity tracking during break periods / start activity tracking during playing periods.

### DIFF
--- a/source/ActivityTracking.mc
+++ b/source/ActivityTracking.mc
@@ -38,6 +38,24 @@ module ActivityTracking {
         }
     }
 
+    function pauseTracking() {
+        if ( actRecSession != null && actRecSession.isRecording() ) {
+            var stopped = false;
+            do {
+            	stopped = actRecSession.stop();
+            } while( stopped == false );
+        }
+    }
+
+    function unpauseTracking() {
+        if ( actRecSession != null && ! actRecSession.isRecording() ) {
+            var started = false;
+            do {
+                started = actRecSession.start();
+            } while( started == false );
+        }
+    }
+
     function endTracking() {
         if( actRecSession != null && actRecSession.isRecording() )
         {

--- a/source/BreakPeriod.mc
+++ b/source/BreakPeriod.mc
@@ -18,11 +18,13 @@
 using Toybox.System as Sys;
 using Toybox.Application as app;
 
+using ActivityTracking as Tracker;
 using HelperFunctions as func;
 
 class BreakPeriod extends Period {
     function initialize(dur) {
         Period.initialize(dur);
+        Tracker.pauseTracking();
     }
 
     // Determine if the break is almost complete

--- a/source/PlayingPeriod.mc
+++ b/source/PlayingPeriod.mc
@@ -17,6 +17,7 @@
 
 using Toybox.System as Sys;
 
+using ActivityTracking as Tracker;
 using HelperFunctions as func;
 
 class PlayingPeriod extends Period {
@@ -26,6 +27,8 @@ class PlayingPeriod extends Period {
 
     function initialize(dur) {
         Period.initialize(dur);
+
+        Tracker.unpauseTracking();
 
         stoppageTime      = 0;
         trackingStoppage  = false;


### PR DESCRIPTION
This PR is a small change that automatically stops activity tracking during break periods and starts activity tracking during playing periods.

This change does not add a configuration item that would allow the user to turn the feature on/off. Having data about a halftime trip to the bathroom doesn't seem particularly useful to me, but perhaps somebody can make a case for it.

See also Issue #12.