### PR TITLE
Treat each period as a lap or a separate activity.

### DIFF
--- a/resources/strings/general_strings.xml
+++ b/resources/strings/general_strings.xml
@@ -5,6 +5,7 @@
 	<string id="NCAAMode_StorageID"       >ncaa_mode</string>
 	<string id="DarkMode_StorageID"       >background_color</string>
 	<string id="ThickRing_StorageID"       >thick_ring</string>
+	<string id="SeparateActivities_StorageID"       >separate_activities</string>
 
     <string id="PeriodLength_StorageID"   >period_len</string>    
     <string id="NumPeriods_StorageID"     >num_periods</string>

--- a/resources/strings/main_menu_strings.xml
+++ b/resources/strings/main_menu_strings.xml
@@ -7,4 +7,5 @@
     <string id="NCAAMode_MenuLabel"       >NCAA Mode</string>
     <string id="DarkMode_MenuLabel"       >Dark Mode</string>
     <string id="ThickRing_MenuLabel"      >Thick Time Ring</string>
+	<string id="SeparateActivities_MenuLabel">Separate Activities</string>
 </strings>

--- a/source/ActivityTracking.mc
+++ b/source/ActivityTracking.mc
@@ -59,6 +59,16 @@ module ActivityTracking {
         actRecSession = null;
     }
 
+    function isActiveSession() {
+        return (actRecSession != null);
+    }
+
+    function addLap() {
+        if (isActiveSession()) {
+            actRecSession.addLap();
+        }
+    }
+
     function getCurHeartRate() {
         var info = Act.getActivityInfo().currentHeartRate;
         if (info != null) {

--- a/source/AppData.mc
+++ b/source/AppData.mc
@@ -28,6 +28,7 @@ class AppData {
 	hidden static var ncaaMode;
 	hidden static var darkMode;
 	hidden static var thickRing;
+    hidden static var separateActivities;
 	
     hidden static var periodLength;
     hidden static var numPeriods;
@@ -60,6 +61,11 @@ class AppData {
 		if (thickRing == null) {
 			setThickRing(false);
 		}
+
+        separateActivities  = Store.getValue(Ui.loadResource(Rez.Strings.SeparateActivities_StorageID));
+        if (separateActivities == null) {
+            setSeparateActivities(false);
+        }
     
         periodLength    = Store.getValue(Ui.loadResource(Rez.Strings.PeriodLength_StorageID));
         if (periodLength == null) {
@@ -103,6 +109,8 @@ class AppData {
 		draw.setDarkMode(darkMode);
     	
     	thickRing       = Store.getValue(Ui.loadResource(Rez.Strings.ThickRing_StorageID));
+
+        separateActivities  = Store.getValue(Ui.loadResource(Rez.Strings.SeparateActivities_StorageID));
     	
         periodLength   = Store.getValue(Ui.loadResource(Rez.Strings.PeriodLength_StorageID));
         numPeriods     = Store.getValue(Ui.loadResource(Rez.Strings.NumPeriods_StorageID));
@@ -126,6 +134,9 @@ class AppData {
     		case Ui.loadResource(Rez.Strings.ThickRing_StorageID) :
     			return thickRing;
     			break;
+            case Ui.loadResource(Rez.Strings.SeparateActivities_StorageID) :
+                return separateActivities;
+                break;
             case Ui.loadResource(Rez.Strings.PeriodLength_StorageID)   :
                 return periodLength;
                 break;
@@ -161,6 +172,9 @@ class AppData {
     		case Ui.loadResource(Rez.Strings.ThickRing_StorageID) :
     			setThickRing(val);
     			break;
+            case Ui.loadResource(Rez.Strings.SeparateActivities_StorageID) :
+                setSeparateActivities(val);
+                break;
             case Ui.loadResource(Rez.Strings.PeriodLength_StorageID)   :
                 setPeriodLength(val);
                 break;
@@ -198,6 +212,10 @@ class AppData {
 	static function getThickRing() {
 		return thickRing;
 	}
+
+    static function getSeparateActivities() {
+        return separateActivities;
+    }
 
     static function getPeriodLength() {
         return periodLength;
@@ -245,6 +263,11 @@ class AppData {
 		thickRing = val;
 		Store.setValue(Ui.loadResource(Rez.Strings.ThickRing_StorageID), val);
 	}
+
+    static function setSeparateActivities(val) {
+        separateActivities = val;
+        Store.setValue(Ui.loadResource(Rez.Strings.SeparateActivities_StorageID), val);
+    }
 
     static function setPeriodLength(val) {
         periodLength = val;

--- a/source/MatchData.mc
+++ b/source/MatchData.mc
@@ -43,13 +43,20 @@ module MatchData {
         if (playingPeriod == 0) {
             nextPeriod();
 
-            Tracker.startTracking();
+            // If the Separate Activities option is on, then
+            // tracking is managed within the PlayingPeriod.
+            // Otherwise start tracking here.
+            if (! AppData.getSeparateActivities()) {
+                Tracker.startTracking();
+            }
         }
     }
 
     // Function which completely ends the match
     function stopMatch() {
-        Tracker.endTracking();
+        if (Tracker.isActiveSession()) {
+            Tracker.endTracking();
+        }
 
         initMatchData();
     }
@@ -83,6 +90,12 @@ module MatchData {
         } else {
             stopMatch();
             return;
+        }
+
+        // If we are not treating each period as a separate
+        // activity, then we'll use laps instead.
+        if (! AppData.getSeparateActivities()) {
+            Tracker.addLap();
         }
     }
 

--- a/source/PlayingPeriod.mc
+++ b/source/PlayingPeriod.mc
@@ -17,6 +17,7 @@
 
 using Toybox.System as Sys;
 
+using ActivityTracking as Tracker;
 using HelperFunctions as func;
 
 class PlayingPeriod extends Period {
@@ -26,6 +27,10 @@ class PlayingPeriod extends Period {
 
     function initialize(dur) {
         Period.initialize(dur);
+
+        if (AppData.getSeparateActivities() && ! Tracker.isActiveSession()) {
+            Tracker.startTracking();
+        }
 
         stoppageTime      = 0;
         trackingStoppage  = false;
@@ -51,6 +56,14 @@ class PlayingPeriod extends Period {
         Period.stop();
 
         trackingStoppage = false;
+    }
+
+    function end() {
+        Period.end();
+        
+        if (AppData.getSeparateActivities() && Tracker.isActiveSession()) {
+            Tracker.endTracking();
+        }
     }
 
     /**********************************************************/

--- a/source/UI/Menus/MainMenuInputDelegate.mc
+++ b/source/UI/Menus/MainMenuInputDelegate.mc
@@ -50,6 +50,9 @@ class MainMenuInputDelegate extends Ui.Menu2InputDelegate {
 			case :ThickRing_MenuID    :
 				AppData.setThickRing(item.isEnabled());
 				break;
+            case :SeparateActivities_MenuID :
+                AppData.setSeparateActivities(item.isEnabled());
+                break;
 			default:
 				Sys.println(item.getId());
         }

--- a/source/UI/Menus/Menus.mc
+++ b/source/UI/Menus/Menus.mc
@@ -48,6 +48,10 @@ module Menus {
 		menu.addItem(
 			new Ui.ToggleMenuItem(Rez.Strings.ThickRing_MenuLabel, null, :ThickRing_MenuID, AppData.getThickRing(), null)
 		);
+
+		menu.addItem(
+			new Ui.ToggleMenuItem(Rez.Strings.SeparateActivities_MenuLabel, null, :SeparateActivities_MenuID, AppData.getSeparateActivities(), null)
+		);
 		
 		return menu;
 	}


### PR DESCRIPTION
This PR adds two related features.

First, by default each period is treated as a separate lap. That allows for easier separation and viewing of period-specific data in Garmin Connect or elsewhere.

Second, a new "Separate Activities" toggle is added to the menu. If turned on, each playing period is treated as a separate activity. Break periods are excluded.

See also Issue #3.