### PR TITLE
Show distance rounded to hundredths instead of tenths.

### DIFF
--- a/source/UI/ActivityInfoView.mc
+++ b/source/UI/ActivityInfoView.mc
@@ -113,6 +113,6 @@ class ActivityInfoView extends Ui.View {
     	}
     
     	draw.centerBottomLabel(draw.DEFAULT_COLOR, label, dc);
-    	draw.centerBottom(draw.DEFAULT_COLOR, dist.format("%02.1f"), dc);
+    	draw.centerBottom(draw.DEFAULT_COLOR, dist.format("%02.2f"), dc);
     }
 }


### PR DESCRIPTION
This PR modifies the display of distance (kilometers or miles) so that it is rounded to the nearest hundredth (.0x) instead of the nearest tenth (.x). This way the distance data displayed in the app matches the distance data displayed in the Garmin Connect app and elsewhere.