### PR TITLE
Add ability to configure reminder interval.

### DIFF
--- a/resources/strings/general_strings.xml
+++ b/resources/strings/general_strings.xml
@@ -2,6 +2,8 @@
     <string id="AppName">RefWatch+</string>
 
 	<string id="BatterySaver_StorageID"   >batter_saver</string>
+    <string id="ReminderInterval_StorageID"       >reminder_interval</string>
+    <string id="Seconds_Label"        >Seconds</string>
 	<string id="NCAAMode_StorageID"       >ncaa_mode</string>
 	<string id="DarkMode_StorageID"       >background_color</string>
 	<string id="ThickRing_StorageID"       >thick_ring</string>

--- a/resources/strings/main_menu_strings.xml
+++ b/resources/strings/main_menu_strings.xml
@@ -4,6 +4,7 @@
     <string id="EndMatch_MenuLabel"       >End Match</string>
     <string id="TimingMenu_MenuLabel"     >Match Times</string>
     <string id="BatterySaver_MenuLabel"   >Battery Saver</string>
+    <string id="ReminderInterval_MenuLabel"       >Reminder Interval</string>
     <string id="NCAAMode_MenuLabel"       >NCAA Mode</string>
     <string id="DarkMode_MenuLabel"       >Dark Mode</string>
     <string id="ThickRing_MenuLabel"      >Thick Time Ring</string>

--- a/source/AppData.mc
+++ b/source/AppData.mc
@@ -22,9 +22,11 @@ using Toybox.Graphics as Gfx;
 
 using RefreshTimer as RTime;
 using ViewDrawables as draw;
+using Toybox.System;
 
 class AppData {
 	hidden static var batterySaver;
+    hidden static var reminderInterval;
 	hidden static var ncaaMode;
 	hidden static var darkMode;
 	hidden static var thickRing;
@@ -44,6 +46,11 @@ class AppData {
     	batterySaver    = Store.getValue(Ui.loadResource(Rez.Strings.BatterySaver_StorageID));
         if (batterySaver == null) {
             setBatterySaver(false);
+        }
+
+        reminderInterval      = Store.getValue(Ui.loadResource(Rez.Strings.ReminderInterval_StorageID));
+        if (reminderInterval == null) {
+            setReminderInterval(10);
         }
         
         ncaaMode        = Store.getValue(Ui.loadResource(Rez.Strings.NCAAMode_StorageID));
@@ -104,6 +111,7 @@ class AppData {
     	
     	thickRing       = Store.getValue(Ui.loadResource(Rez.Strings.ThickRing_StorageID));
     	
+        reminderInterval    = Store.getValue(Ui.loadResource(Rez.Strings.ReminderInterval_StorageID));
         periodLength   = Store.getValue(Ui.loadResource(Rez.Strings.PeriodLength_StorageID));
         numPeriods     = Store.getValue(Ui.loadResource(Rez.Strings.NumPeriods_StorageID));
         breakLength    = Store.getValue(Ui.loadResource(Rez.Strings.BreakLength_StorageID));
@@ -126,6 +134,9 @@ class AppData {
     		case Ui.loadResource(Rez.Strings.ThickRing_StorageID) :
     			return thickRing;
     			break;
+            case Ui.loadResource(Rez.Strings.ReminderInterval_StorageID) :
+                return reminderInterval;
+                break;
             case Ui.loadResource(Rez.Strings.PeriodLength_StorageID)   :
                 return periodLength;
                 break;
@@ -161,6 +172,9 @@ class AppData {
     		case Ui.loadResource(Rez.Strings.ThickRing_StorageID) :
     			setThickRing(val);
     			break;
+            case Ui.loadResource(Rez.Strings.ReminderInterval_StorageID) :
+                setReminderInterval(val);
+                break;
             case Ui.loadResource(Rez.Strings.PeriodLength_StorageID)   :
                 setPeriodLength(val);
                 break;
@@ -198,6 +212,10 @@ class AppData {
 	static function getThickRing() {
 		return thickRing;
 	}
+
+    static function getReminderInterval() {
+        return reminderInterval;
+    }
 
     static function getPeriodLength() {
         return periodLength;
@@ -249,6 +267,11 @@ class AppData {
     static function setPeriodLength(val) {
         periodLength = val;
         Store.setValue(Ui.loadResource(Rez.Strings.PeriodLength_StorageID), val);
+    }
+
+    static function setReminderInterval(val) {
+        reminderInterval = val;
+        Store.setValue(Ui.loadResource(Rez.Strings.ReminderInterval_StorageID), val);
     }
 
     static function setNumPeriods(val) {

--- a/source/UI/Menus/MainMenuInputDelegate.mc
+++ b/source/UI/Menus/MainMenuInputDelegate.mc
@@ -38,6 +38,11 @@ class MainMenuInputDelegate extends Ui.Menu2InputDelegate {
         					 new TimingMenuInputDelegate(), 
         					 Ui.SLIDE_LEFT );
 			 	break;
+            case :ReminderInterval_MenuID   :
+                Ui.pushView(new NumPicker5(Ui.loadResource(Rez.Strings.Seconds_Label), Ui.loadResource(Rez.Strings.ReminderInterval_StorageID)),
+                            new NumPickerDelegate(Ui.loadResource(Rez.Strings.ReminderInterval_StorageID)),
+                            Ui.SLIDE_LEFT);
+                break;
 		 	case :NCAAMode_MenuID       :
 		 		AppData.setNCAAMode(item.isEnabled());
                 break;

--- a/source/UI/Menus/Menus.mc
+++ b/source/UI/Menus/Menus.mc
@@ -32,6 +32,10 @@ module Menus {
 		menu.addItem(
 			new Ui.MenuItem(Rez.Strings.TimingMenu_MenuLabel, null, :TimingMenu_MenuID, null)
 		);
+
+		menu.addItem(
+			new Ui.MenuItem(Rez.Strings.ReminderInterval_MenuLabel, null, :ReminderInterval_MenuID, null)
+		);
 		
 		menu.addItem(
 			new Ui.ToggleMenuItem(Rez.Strings.NCAAMode_MenuLabel, null, :NCAAMode_MenuID, AppData.getNCAAMode(), null)

--- a/source/VibrationController.mc
+++ b/source/VibrationController.mc
@@ -159,7 +159,7 @@ module VibrationController {
     function stoppageTrackingReminder() {
 
         if (MatchData.getCurPeriod().isTrackingStoppage()) {
-            if (MatchData.getCurPeriod().getSecStoppage() % 10 == 0) {
+            if (MatchData.getCurPeriod().getSecStoppage() % AppData.getReminderInterval() == 0) {
                 return true;
             }
         }

--- a/source/pickers/NumPicker5.mc
+++ b/source/pickers/NumPicker5.mc
@@ -1,0 +1,60 @@
+/***************************************************************************
+ * This file is part of RefWatchPlus                                       *
+ *                                                                         *
+ * RefWatchPlus is free software: you can redistribute it and/or modify    *
+ * it under the terms of the GNU General Public License as published by    *
+ * the Free Software Foundation, either version 3 of the License, or       *
+ * (at your option) any later version.                                     *
+ *                                                                         *
+ * RefWatchPlus is distributed in the hope that it will be useful,         *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of          *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
+ * GNU General Public License for more details.                            *
+ *                                                                         *
+ * You should have received a copy of the GNU General Public License       *
+ * along with RefWatchPlus.  If not, see <https://www.gnu.org/licenses/>.  *
+ ***************************************************************************/
+ 
+using Toybox.WatchUi as Ui;
+using Toybox.Graphics as Gfx;
+using Toybox.Application;
+using Toybox.System as Sys;
+using Toybox.Test;
+
+using ViewDrawables as draw;
+
+class NumPicker5 extends Ui.Picker {
+
+    function initialize(titleName, prop) {
+        var title;
+
+        if (Toybox has :Test) {
+            Test.assertMessage(titleName instanceof String, "NumPicker: \'titleName\' not a string");
+            Test.assertMessage(prop      instanceof String, "NumPicker: \'prop\' not a string");
+            Test.assertMessage(AppData.get(prop) != null, "NumPicker: Invalid Property");
+        }
+
+        title = new Ui.Text({:text=>titleName, :font=>Gfx.FONT_MEDIUM, :locX=>Ui.LAYOUT_HALIGN_CENTER, :locY=>Ui.LAYOUT_VALIGN_BOTTOM, :color=>Gfx.COLOR_WHITE});
+
+        var factories = new [1];
+        var stepSize = 5;
+
+        factories[0] = new NumberFactory(5, 60, stepSize, {:font=>Graphics.FONT_MEDIUM});
+
+        var defaults = new [1];
+        // This is weird.
+        // When stepSize is a value other than the default (1), the value
+        // returned by .getIndex() is off by (stepSize - 1). In other
+        // words, when getIndex() should return 0 and the stepSize is 5,
+        // getIndex instead returns -4. As you can imagine, that causes
+        // calamities and disasters galore.
+        // Is there any sane reason for that to be true? It sure smells
+        // like a bug, but perhaps I misunderstand something about
+        // NumberFactory or getIndex. Neither is documented particularly
+        // well (or at all), so seeking help there doesn't help. 
+        defaults[0] = factories[0].getIndex(AppData.get(prop)) + stepSize - 1;
+
+        Picker.initialize({:title=>title, :pattern=>factories, :defaults=>defaults});
+    }
+}
+


### PR DESCRIPTION
This PR adds a new "Reminder Interval" menu item and the ability to configure the stoppage time reminder vibration interval. Acceptable values are 5 to 60 seconds. The default value remains at 10 seconds.

Please take note of the comment in NumPicker5.mc starting at line 45. It seems that when you use NumberFactory with a step size of something other than 1, and then you call getIndex(someValue) on the generated list, the index returned will be off by one less than the step size. That seems like a bug to me, but what do I know? Perhaps somebody can show me how badly I misunderstand how all that is supposed to work.

This PR is related to issue #13.