### PR TITLE
Fix bug where activity tracking didn't unpause in second half.

### DIFF
--- a/source/PlayingPeriod.mc
+++ b/source/PlayingPeriod.mc
@@ -30,6 +30,8 @@ class PlayingPeriod extends Period {
         
         if (AppData.getSeparateActivities() && ! Tracker.isActiveSession()) {
             Tracker.startTracking();
+        } else {
+            Tracker.unpauseTracking();
         }
 
         stoppageTime      = 0;


### PR DESCRIPTION
I noticed a bug that can occur when "Separate Activities" is off. The activity tracking would be correctly paused at the end of the first half, but it would not resume at the start of the second half. This code change fixes that. I have tested in the simulator and during some short walks outside. Tonight I will test it during an actual match.